### PR TITLE
custom table component for a shallow json document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .ipynb_checkpoints/
 h2/
 log/
+.idea

--- a/.vuepress/components/json-table.vue
+++ b/.vuepress/components/json-table.vue
@@ -1,0 +1,29 @@
+<template>
+  <table>
+    <thead>
+      <tr>
+        <th>Key</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+
+    <tbody>
+        <tr v-for="(value, propertyName) in json">
+          <td>{{ propertyName }}</td>
+          <td>{{ value }}</td>
+        </tr>
+    </tbody>
+  </table>
+
+</template>
+
+<script>
+export default {
+  props: ['json'],
+  name: "json-table"
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/.vuepress/components/json-table.vue
+++ b/.vuepress/components/json-table.vue
@@ -2,15 +2,17 @@
   <table>
     <thead>
       <tr>
-        <th>Key</th>
-        <th>Description</th>
+        <th class="properties-table-key-header">Key</th>
+        <th class="properties-table-type-header">Type</th>
+        <th class="properties-table-description-header">Description</th>
       </tr>
     </thead>
 
     <tbody>
         <tr v-for="(value, propertyName) in json">
-          <td>{{ propertyName }}</td>
-          <td>{{ value }}</td>
+          <td class="properties-table-key-header"><code>{{ propertyName }}</code></td>
+          <td class="properties-table-key-header">{{ value.type }}</td>
+          <td class="properties-table-description-header">{{ value.description }}</td>
         </tr>
     </tbody>
   </table>
@@ -25,5 +27,15 @@ export default {
 </script>
 
 <style scoped>
+
+.properties-table-key-header {
+  max-width: 17rem;
+  white-space: pre-line;
+  overflow-wrap: break-word;
+}
+
+.properties-table-description-header {
+
+}
 
 </style>

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -103,7 +103,8 @@ function genGuideSidebarConfig() {
         	children: [
                 'advanced/predefined',
                 'advanced/logging',
-                'advanced/caching'
+                'advanced/caching',
+                'advanced/properties'
         	]
           },
         {

--- a/guide/advanced/properties.md
+++ b/guide/advanced/properties.md
@@ -13,7 +13,7 @@
             }
         },
         async created() {
-            const response = await fetch("https://jsonplaceholder.typicode.com/posts/1/comments");
+            const response = await fetch("https://raw.githubusercontent.com/ontop/ontop/feature/property-description-with-type/documentation/property_description.json");
             const responseJson = await response.json();
             this.json = responseJson;
         }

--- a/guide/advanced/properties.md
+++ b/guide/advanced/properties.md
@@ -1,0 +1,21 @@
+# Properties
+
+
+### Top-level keys
+
+<json-table v-bind:json="json"/>
+
+<script>
+    export default {
+        data() {
+            return {
+                json : {}
+            }
+        },
+        async created() {
+            const response = await fetch("https://jsonplaceholder.typicode.com/posts/1/comments");
+            const responseJson = await response.json();
+            this.json = responseJson;
+        }
+    }
+</script>


### PR DESCRIPTION
Hi @bcogrel ,

I re-worked the approach and created a custom component as per https://v1.vuepress.vuejs.org/guide/using-vue.html#using-components

The component assumes a 'shallow' JSON object since it will only display two columns: Key and Description. These table headers can be changed in the component under .vuepress/components/json-table.vue

The component is easy to re-use by simply giving a json document to it

Thanks,