### PR TITLE
Custom table component adjusted to SSR

### DIFF
--- a/.vuepress/components/json-table.vue
+++ b/.vuepress/components/json-table.vue
@@ -12,7 +12,9 @@
         <tr v-for="(value, propertyName) in json">
           <td class="properties-table-key-header"><code>{{ propertyName }}</code></td>
           <td class="properties-table-key-header">{{ value.type }}</td>
-          <td class="properties-table-description-header"> <markdown-it-vue :content="value.description"></markdown-it-vue></td>
+          <td class="properties-table-description-header">
+            <component v-if="dynamicComponent" :is="dynamicComponent" :content="value.description"></component>
+          </td>
         </tr>
     </tbody>
   </table>
@@ -22,7 +24,17 @@
 <script>
 export default {
   props: ['json'],
-  name: "json-table"
+  name: "json-table",
+  data() {
+    return {
+      dynamicComponent: null
+    }
+  },
+  mounted () {
+    import('markdown-it-vue').then(module => {
+      this.dynamicComponent = module.default
+    })
+  }
 }
 </script>
 

--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -1,5 +1,5 @@
 // async function is also supported, too
-import MarkdownItVue from 'markdown-it-vue';
+// import MarkdownItVue from 'markdown-it-vue';
 export default ({
                     Vue, // the version of Vue being used in the VuePress app
                     options, // the options for the root Vue instance
@@ -9,5 +9,5 @@ export default ({
                 }) => {
     // ...apply enhancements to the app
     // Vue.component('vue-json-to-table', VueJsonToTable)
-    Vue.use(MarkdownItVue)
+    // Vue.use(MarkdownItVue)
 }

--- a/guide/advanced/properties.md
+++ b/guide/advanced/properties.md
@@ -3,7 +3,10 @@
 
 ### Top-level keys
 
-<json-table v-bind:json="json"/>
+<ClientOnly>
+  <json-table v-bind:json="json"/>
+</ClientOnly>
+
 
 <script>
     export default {
@@ -12,7 +15,7 @@
                 json : {}
             }
         },
-        async created() {
+        async mounted() {
             const response = await fetch("https://raw.githubusercontent.com/ontop/ontop/feature/property-description-with-type/documentation/property_description.json");
             const responseJson = await response.json();
             this.json = responseJson;


### PR DESCRIPTION
The build error with message 'window not found' comes from vuepress server side rendering the pages. Our table component tries to access the browser 'window' variable which does not exist while building on the backend. 

This code configures and makes some adjustments to make sure only relevant parts are available during SSR and the browser functions remain on the client.

A further improvement would be to add a loading message while the client fetches the remote JSON