### PR TITLE
Fixed error in lenses tutorial setup

### DIFF
--- a/tutorial/lenses/setup.md
+++ b/tutorial/lenses/setup.md
@@ -16,7 +16,7 @@ For this tutorial, we use a SPARQL endpoint provided by ontop to test our mappin
 
 1. Download [Ontop CLI](https://github.com/ontop/ontop/releases) and unzip it to a directory, which is denoted as `$ONTOP_CLI_DIR` below.
 2. Copy the DuckDB jdbc driver to `$ONTOP_CLI_DIR/jdbc` from the *duckdb.zip* archive.
-3. Copy the database file `data/tutorial.db` to `$ONTOP_CLI_DIR`.
+3. Copy the database file `data/tutorial.db` into a new directory `$ONTOP_CLI_DIR/data`.
 4. Paste your *mapping* and *lenses* files, as well as the *ontology* and *properties* files into a new directory called `input` inside of `$ONTOP_CLI`.
      - You will create the *mapping* and *lenses* files throughout the course of this tutorial. Alternatively, the *duckdb.zip* archive contains one directory for each of the lens tutorials, with sample mappings and lenses already pre-made.
      - The *ontology* and *properties* files will be the same throughout all tutorials. They are already provided in the *duckdb.zip* archive.


### PR DESCRIPTION
The database file has to be copied into a directory called `data`; included this information in the tutorial